### PR TITLE
optional chaining, short circuits the expression if accessed property…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,8 @@
-console.log("Hey!");
+let obj ={
+  a:"abc"
+}
+console.log(obj.a)//abc
+console.log(obj.b)//undefined
+console.log(obj.a.charAt(0)) //a
+console.log(obj.b?.charAt(0))//undefined
+console.log(obj.b.charAt(0))//type error


### PR DESCRIPTION
… is undefined or null and evaluates to null instead of throwing type error